### PR TITLE
Don't serialize empty policy_ref

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ type signedPolicyStep struct {
 }
 
 type signedPolicy struct {
-	PolicyRef []byte             `json:"policy_ref"`
+	PolicyRef []byte             `json:"policy_ref,omitempty"`
 	Steps     []signedPolicyStep `json:"steps"`
 	Signature []byte             `json:"signature"`
 }


### PR DESCRIPTION
Otherwise clevis-pin-tpm2 fail with `Error during parsing operation: Error: Not all of policy pubkey, path and ref are specified`